### PR TITLE
perf: vectorize n_x loops and eliminate hot-path allocations (#39)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,38 @@ build: Changes to the build process or tools.
 
 # Changelog
 
+## v2.0.2 (unreleased)
+
+### Fix
+
+- Updated `notebooks/runtime.ipynb` to the current API (`jenn.utilities.sample`
+  with `jenn.synthetic_data.rastrigin`); it still called the pre-`v2.0.0`
+  `jenn.synthetic.Rastrigin.sample`, breaking the notebook test suite
+
+### Perf
+
+- Vectorized the `n_x` partial-derivative loop in `next_layer_partials`
+  (`propagation.py`) with a single `np.tensordot`, also removing a matmul that
+  was computed twice per iteration
+- Vectorized the `n_x` loop in `gradient_enhancement` (`propagation.py`) into
+  BLAS-backed `dot`/`tensordot` contractions
+- Replaced the `n_y`/`n_x` Python loops in `SquaredLoss.evaluate` and
+  `GradientEnhancement.evaluate` (`cost.py`) with `np.sum(np.square(...))`
+- Write the input-layer identity partial in place via broadcasting in
+  `first_layer_partials` (`propagation.py`), removing the per-pass
+  `(n_x, n_x, m)` allocation (and the now-unused `eye` helper)
+- Compute `g'(z) * dA` once into a reused cache buffer in `next_layer_backward`
+  (`propagation.py`, `cache.py`) instead of three times
+- Made `Tanh`/`Relu` `first_derivative` fully in-place (`activation.py`),
+  removing per-call temporaries
+
+### Test
+
+- Added a finite-difference gradient check for gradient-enhanced backprop with
+  `n_x >= 2` (`test_propagation.py`), guarding the vectorized `n_x` paths
+- Added `scripts/benchmark.py` and a `benchmark` pixi task to measure the
+  training hot path (micro + airfoil end-to-end)
+
 ## v2.0.1 (2026-07-17)
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,16 @@ build: Changes to the build process or tools.
 
 # Changelog
 
-## v2.0.2 (unreleased)
+## v2.0.1 (2026-07-17)
 
 ### Fix
 
+- Fixed off-by-one in `data.py` mini-batching that dropped the last mini-batch
+- Fixed `_safe_divide` in `data.py` mutating the caller's array (now uses `np.where`)
+- Fixed gradient-enhancement weight in `cost.py` (applied as `gamma`, not `gamma^3`)
+- Fixed backtracking line-search decay in `optimization.py` (now linear `tau`, not `tau^(2^i)`)
+- Fixed ADAM bias counter in `optimization.py` to use object identity instead of `id()`
+- Fixed invalid f-string format spec in `optimization.py` (`{y::.6f}` -> `{y:.6f}`)
 - Updated `notebooks/runtime.ipynb` to the current API (`jenn.utilities.sample`
   with `jenn.synthetic_data.rastrigin`); it still called the pre-`v2.0.0`
   `jenn.synthetic.Rastrigin.sample`, breaking the notebook test suite
@@ -45,25 +51,11 @@ build: Changes to the build process or tools.
 
 ### Test
 
+- Fixed `test_model_forward` to call `model_forward` (was erroneously calling `partials_forward`)
 - Added a finite-difference gradient check for gradient-enhanced backprop with
   `n_x >= 2` (`test_propagation.py`), guarding the vectorized `n_x` paths
 - Added `scripts/benchmark.py` and a `benchmark` pixi task to measure the
   training hot path (micro + airfoil end-to-end)
-
-## v2.0.1 (2026-07-17)
-
-### Fix
-
-- Fixed off-by-one in `data.py` mini-batching that dropped the last mini-batch
-- Fixed `_safe_divide` in `data.py` mutating the caller's array (now uses `np.where`)
-- Fixed gradient-enhancement weight in `cost.py` (applied as `gamma`, not `gamma^3`)
-- Fixed backtracking line-search decay in `optimization.py` (now linear `tau`, not `tau^(2^i)`)
-- Fixed ADAM bias counter in `optimization.py` to use object identity instead of `id()`
-- Fixed invalid f-string format spec in `optimization.py` (`{y::.6f}` -> `{y:.6f}`)
-
-### Test
-
-- Fixed `test_model_forward` to call `model_forward` (was erroneously calling `partials_forward`)
 
 ### Build
 

--- a/benchmark_results.json
+++ b/benchmark_results.json
@@ -1,0 +1,70 @@
+{
+  "runs": {
+    "baseline": {
+      "timestamp": "2026-07-17T12:45:11.853612+00:00",
+      "platform": "macOS-26.5.1-arm64-arm-64bit-Mach-O",
+      "python": "3.14.6",
+      "numpy": "2.5.1",
+      "jenn": "2.0.1",
+      "micro": {
+        "shape": {
+          "n_x": 16,
+          "m": 5000,
+          "layer_sizes": [
+            16,
+            12,
+            12,
+            1
+          ]
+        },
+        "gradient_enhancement_ms": 7.889749977039173,
+        "next_layer_partials_ms": 2.7479580021463335
+      },
+      "e2e": {
+        "shape": {
+          "n_x": 16,
+          "m": 42039
+        },
+        "config": {
+          "epochs": 25,
+          "max_iter": 2,
+          "seed": 42
+        },
+        "train_seconds": 20.65560454101069
+      }
+    },
+    "vectorized": {
+      "timestamp": "2026-07-17T12:48:48.499200+00:00",
+      "platform": "macOS-26.5.1-arm64-arm-64bit-Mach-O",
+      "python": "3.14.6",
+      "numpy": "2.5.1",
+      "jenn": "2.0.1",
+      "micro": {
+        "shape": {
+          "n_x": 16,
+          "m": 5000,
+          "layer_sizes": [
+            16,
+            12,
+            12,
+            1
+          ]
+        },
+        "gradient_enhancement_ms": 4.657417011912912,
+        "next_layer_partials_ms": 1.594875007867813
+      },
+      "e2e": {
+        "shape": {
+          "n_x": 16,
+          "m": 42039
+        },
+        "config": {
+          "epochs": 25,
+          "max_iter": 2,
+          "seed": 42
+        },
+        "train_seconds": 12.839697332994547
+      }
+    }
+  }
+}

--- a/notebooks/runtime.ipynb
+++ b/notebooks/runtime.ipynb
@@ -36,31 +36,7 @@
    "id": "1c1c3f6b-3633-4f71-92bb-217331e3bbfe",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "def timeit(samples: int, width: int = 10, depth: int = 1):\n",
-    "    \"\"\"Return elapsed time.\"\"\"\n",
-    "    x_train, y_train, dydx_train = jenn.synthetic.Rastrigin.sample(\n",
-    "        m_random=samples,\n",
-    "        m_levels=0,\n",
-    "        lb=(-1.0, -1.0),\n",
-    "        ub=(1.5, 1.5),\n",
-    "    )\n",
-    "    tic = time.time()\n",
-    "    _ = jenn.NeuralNet(\n",
-    "        layer_sizes=[2] + [width] * depth + [1],\n",
-    "    ).fit(\n",
-    "        x=x_train,\n",
-    "        y=y_train,\n",
-    "        dydx=dydx_train,\n",
-    "        max_iter=200,\n",
-    "        alpha=0.05,\n",
-    "        lambd=0.0001,\n",
-    "        is_normalize=True,\n",
-    "        is_verbose=False,\n",
-    "    )\n",
-    "    toc = time.time()\n",
-    "    return toc - tic"
-   ]
+   "source": "def timeit(samples: int, width: int = 10, depth: int = 1):\n    \"\"\"Return elapsed time.\"\"\"\n    x_train, y_train, dydx_train = jenn.utilities.sample(\n        f=jenn.synthetic_data.rastrigin.compute,\n        f_prime=jenn.synthetic_data.rastrigin.compute_partials,\n        m_random=samples,\n        m_levels=0,\n        lb=(-1.0, -1.0),\n        ub=(1.5, 1.5),\n    )\n    tic = time.time()\n    _ = jenn.NeuralNet(\n        layer_sizes=[2] + [width] * depth + [1],\n    ).fit(\n        x=x_train,\n        y=y_train,\n        dydx=dydx_train,\n        max_iter=200,\n        alpha=0.05,\n        lambd=0.0001,\n        is_normalize=True,\n        is_verbose=False,\n    )\n    toc = time.time()\n    return toc - tic"
   },
   {
    "cell_type": "code",

--- a/pixi.toml
+++ b/pixi.toml
@@ -59,6 +59,11 @@ cmd = "pytest --nbmake --nbmake-timeout=3000 notebooks/*.ipynb"
 inputs = ["src/**/*.py", "notebooks/*.ipynb"]
 depends-on = ["pip-e"]
 
+[feature.test.tasks.benchmark]
+description = "Benchmark training hot path (see scripts/benchmark.py)"
+cmd = "python scripts/benchmark.py"
+depends-on = ["pip-e"]
+
 [feature.lint.tasks.ruff]
 description = "Check Python code for formatting errors. "
 cmd = "ruff format --check && ruff check"

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,173 @@
+"""Performance benchmark for JENN's training hot path (issue #39).
+
+Measures two things and records them to ``benchmark_results.json``:
+
+1. **Micro** — wall-clock of the two hottest functions,
+   :func:`jenn.core.propagation.gradient_enhancement` and
+   :func:`jenn.core.propagation.next_layer_partials`, on synthetic arrays with
+   ``n_x >= 2`` and large ``m`` (the regime the ``for j in range(n_x)`` loops
+   dominate).
+2. **End-to-end** — training the airfoil example
+   (``docs/examples/data`` -> ``n_x=16``, ``m~42k``, gradient-enhanced) with a
+   fixed seed and fixed iteration budget.
+
+The script always calls the *current* implementation in the installed package,
+so run it once before the optimization (``--tag baseline``) and once after
+(``--tag vectorized``) to get a before/after comparison.
+
+Usage::
+
+    pixi run -e dev python scripts/benchmark.py --tag baseline
+    pixi run -e dev python scripts/benchmark.py --tag vectorized --skip-e2e
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import numpy as np
+
+import jenn
+from jenn.core.cache import Cache
+from jenn.core.data import Dataset
+from jenn.core.parameters import Parameters
+from jenn.core.propagation import (
+    gradient_enhancement,
+    model_backward,
+    model_partials_forward,
+    next_layer_partials,
+)
+
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parent
+_RESULTS = _REPO / "benchmark_results.json"
+_AIRFOIL = _REPO / "docs" / "examples" / "data"
+
+
+def _time(fn, repeats: int, inner: int = 1) -> float:
+    """Return median milliseconds per call over ``repeats`` samples."""
+    fn()  # warm up
+    samples = []
+    for _ in range(repeats):
+        t0 = time.perf_counter()
+        for _ in range(inner):
+            fn()
+        samples.append((time.perf_counter() - t0) / inner * 1e3)
+    return statistics.median(samples)
+
+
+def bench_micro(n_x: int = 16, m: int = 5000, repeats: int = 25) -> dict:
+    """Micro-benchmark the two hot propagation functions on one layer."""
+    layer_sizes = [n_x, 12, 12, 1]
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((n_x, m))
+    Y = rng.standard_normal((1, m))
+    J = rng.standard_normal((1, n_x, m))
+
+    parameters = Parameters(layer_sizes, hidden_activation="tanh")
+    parameters.initialize(random_state=1)
+    data = Dataset(X, Y, J)
+    data.set_weights()
+    cache = Cache(layer_sizes, m)
+
+    # Populate the cache (forward + backward) so both functions have real inputs.
+    model_partials_forward(X, parameters, cache)
+    model_backward(data, parameters, cache)
+
+    layer = 2  # a hidden layer (tanh) so second-derivative terms are non-zero
+    ge = _time(lambda: gradient_enhancement(layer, parameters, cache, data), repeats)
+    nlp = _time(lambda: next_layer_partials(layer, parameters, cache), repeats)
+    return {
+        "shape": {"n_x": n_x, "m": m, "layer_sizes": layer_sizes},
+        "gradient_enhancement_ms": ge,
+        "next_layer_partials_ms": nlp,
+    }
+
+
+def _load_airfoil() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    xy = np.loadtxt(_AIRFOIL / "cd_x_y.csv", delimiter=";", dtype=float)
+    X = xy[:, :-1].T
+    Y = xy[:, -1].reshape((-1, 1)).T
+    J = np.loadtxt(_AIRFOIL / "cd_dy.csv", delimiter=";", dtype=float).T
+    n_y, _ = Y.shape
+    n_x, m = X.shape
+    J = J.reshape((n_y, n_x, m))
+    return X, Y, J
+
+
+def bench_e2e(epochs: int = 25, max_iter: int = 2, seed: int = 42) -> dict:
+    """Train the airfoil model end-to-end and time it (fixed seed/budget)."""
+    if not (_AIRFOIL / "cd_x_y.csv").exists():
+        return {"skipped": "airfoil data not found"}
+
+    X, Y, J = _load_airfoil()
+    n_x, m = X.shape
+    n_y, _ = Y.shape
+
+    model = jenn.NeuralNet(layer_sizes=[n_x, 12, 12, n_y])
+    t0 = time.perf_counter()
+    model.fit(
+        x=X,
+        y=Y,
+        dydx=J,
+        alpha=1e-2,
+        lambd=1e-2,
+        gamma=1.0,
+        is_backtracking=True,
+        is_normalize=True,
+        is_verbose=False,
+        max_iter=max_iter,
+        batch_size=1000,
+        epochs=epochs,
+        shuffle=True,
+        random_state=seed,
+    )
+    elapsed = time.perf_counter() - t0
+    return {
+        "shape": {"n_x": n_x, "m": m},
+        "config": {"epochs": epochs, "max_iter": max_iter, "seed": seed},
+        "train_seconds": elapsed,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", default="run", help="label for this run")
+    parser.add_argument("--skip-e2e", action="store_true", help="skip airfoil train")
+    parser.add_argument("--repeats", type=int, default=25)
+    args = parser.parse_args()
+
+    record = {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "numpy": np.__version__,
+        "jenn": jenn.__version__,
+        "micro": bench_micro(repeats=args.repeats),
+    }
+    if not args.skip_e2e:
+        record["e2e"] = bench_e2e()
+
+    results = {}
+    if _RESULTS.exists():
+        results = json.loads(_RESULTS.read_text())
+    results.setdefault("runs", {})[args.tag] = record
+    _RESULTS.write_text(json.dumps(results, indent=2) + "\n")
+
+    m = record["micro"]
+    print(f"[{args.tag}]  numpy {record['numpy']}  {record['platform']}")
+    print(f"  gradient_enhancement : {m['gradient_enhancement_ms']:8.3f} ms")
+    print(f"  next_layer_partials  : {m['next_layer_partials_ms']:8.3f} ms")
+    if "e2e" in record and "train_seconds" in record["e2e"]:
+        print(f"  airfoil train        : {record['e2e']['train_seconds']:8.3f} s")
+    print(f"  -> {_RESULTS}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/jenn/core/activation.py
+++ b/src/jenn/core/activation.py
@@ -115,7 +115,10 @@ class Tanh(Activation):
             y = cls.evaluate(x)
         if dy is None:
             return 1 - np.square(y)
-        dy[:] = 1 - np.square(y, out=dy)
+        # dy = 1 - y**2, fully in place (no "1 - dy" temporary).
+        np.square(y, out=dy)
+        dy *= -1
+        dy += 1
         return dy
 
     @classmethod
@@ -194,7 +197,8 @@ class Relu(Activation):
         if dy is None:
             dy = np.asarray(x > 0, dtype=x.dtype)
         else:
-            dy[:] = np.asarray(x > 0, dtype=x.dtype)
+            # Write the comparison straight into dy (no bool + float temporaries).
+            np.greater(x, 0, out=dy)
         return dy
 
     @classmethod

--- a/src/jenn/core/cache.py
+++ b/src/jenn/core/cache.py
@@ -88,6 +88,7 @@ class Cache:
         self.G_prime_prime: list[np.ndarray] = []  # g'' = d/dz( da/dz )
         self.dA: list[np.ndarray] = []
         self.dA_prime: list[np.ndarray] = []
+        self.dZ: list[np.ndarray] = []  # scratch for g'(z) * dA (reused in backprop)
         for n in self.layer_sizes:
             self.Z.append(np.zeros((n, m)))
             self.Z_prime.append(np.zeros((n, self.n_x, m)))
@@ -97,3 +98,4 @@ class Cache:
             self.A_prime.append(np.zeros((n, self.n_x, m)))
             self.dA.append(np.zeros((n, m)))
             self.dA_prime.append(np.zeros((n, self.n_x, m)))
+            self.dZ.append(np.zeros((n, m)))

--- a/src/jenn/core/cost.py
+++ b/src/jenn/core/cost.py
@@ -44,10 +44,8 @@ class SquaredLoss:
         """
         self.Y_error[:, :] = Y_pred - self.Y_true
         self.Y_error *= np.sqrt(self.Y_weights)
-        cost = 0
-        for j in range(self.n_y):
-            cost += np.dot(self.Y_error[j], self.Y_error[j].T)
-        return np.float64(cost)
+        # sum_j dot(e_j, e_j) over rows is just the sum of squared errors.
+        return np.float64(np.sum(np.square(self.Y_error)))
 
 
 class GradientEnhancement:
@@ -72,12 +70,8 @@ class GradientEnhancement:
         """
         self.J_error[:, :, :] = J_pred - self.J_true
         self.J_error *= np.sqrt(self.J_weights)
-        cost = 0.0
-        for k in range(self.n_y):
-            for j in range(self.n_x):
-                dot_product = np.dot(self.J_error[k, j], self.J_error[k, j].T)
-                cost += np.squeeze(dot_product)
-        return np.float64(cost)
+        # sum_k sum_j dot(e_kj, e_kj) is just the sum of squared partial errors.
+        return np.float64(np.sum(np.square(self.J_error)))
 
 
 class Regularization:

--- a/src/jenn/core/propagation.py
+++ b/src/jenn/core/propagation.py
@@ -21,12 +21,6 @@ import numpy as np
 from .activation import ACTIVATIONS
 
 
-def eye(n: int, m: int) -> np.ndarray:
-    """Copy identify matrix of shape (n, n) m times."""
-    eye = np.eye(n, dtype=float)
-    return np.repeat(eye.reshape((n, n, 1)), m, axis=2)
-
-
 def first_layer_forward(X: np.ndarray, cache: Cache | None = None) -> None:
     """Compute input layer activations (in place).
 
@@ -50,8 +44,10 @@ def first_layer_partials(X: np.ndarray, cache: Cache | None) -> None:
     """
     X = X.astype(float, copy=False)
     if cache is not None:
-        n_x, m = X.shape
-        cache.A_prime[0][:] = eye(n_x, m)
+        n_x = X.shape[0]
+        # Broadcast the identity over the m examples straight into the
+        # pre-allocated buffer (no (n_x, n_x, m) temporary).
+        cache.A_prime[0][:] = np.eye(n_x, dtype=float)[:, :, np.newaxis]
 
 
 def next_layer_partials(layer: int, parameters: Parameters, cache: Cache) -> np.ndarray:
@@ -69,12 +65,10 @@ def next_layer_partials(layer: int, parameters: Parameters, cache: Cache) -> np.
     W = parameters.W[layer]
     g = ACTIVATIONS[parameters.a[layer]]
     cache.G_prime[s][:] = g.first_derivative(cache.Z[s], cache.A[s])
-    for j in range(parameters.n_x):
-        cache.Z_prime[s][:, j, :] = np.dot(W, cache.A_prime[r][:, j, :])
-        cache.A_prime[s][:, j, :] = cache.G_prime[s] * np.dot(
-            W,
-            cache.A_prime[r][:, j, :],
-        )
+    # Vectorized over the n_x partials: one BLAS-backed tensordot replaces the
+    # Python loop (and the redundant W @ A_prime computed twice per iteration).
+    cache.Z_prime[s][:] = np.tensordot(W, cache.A_prime[r], axes=([1], [0]))
+    cache.A_prime[s][:] = cache.G_prime[s][:, np.newaxis, :] * cache.Z_prime[s]
     return cache.A_prime[s]
 
 
@@ -187,12 +181,15 @@ def next_layer_backward(
     r = layer - 1
     g = ACTIVATIONS[parameters.a[s]]
     g.first_derivative(cache.Z[s], cache.A[s], cache.G_prime[s])
-    np.dot(cache.G_prime[s] * cache.dA[s], cache.A[r].T, out=parameters.dW[s])
+    # g'(z) * dA is reused three times below; compute it once into scratch.
+    dZ = cache.dZ[s]
+    np.multiply(cache.G_prime[s], cache.dA[s], out=dZ)
+    np.dot(dZ, cache.A[r].T, out=parameters.dW[s])
     parameters.dW[s] /= data.m
     parameters.dW[s] += lambd / data.m * parameters.W[s]
-    np.sum(cache.G_prime[s] * cache.dA[s], axis=1, keepdims=True, out=parameters.db[s])
+    np.sum(dZ, axis=1, keepdims=True, out=parameters.db[s])
     parameters.db[s] /= data.m
-    np.dot(parameters.W[s].T, cache.G_prime[s] * cache.dA[s], out=cache.dA[r])
+    np.dot(parameters.W[s].T, dZ, out=cache.dA[r])
 
 
 def gradient_enhancement(
@@ -224,36 +221,20 @@ def gradient_enhancement(
         cache.G_prime[s],
     )
     coefficient = 1 / data.m
-    for j in range(parameters.n_x):
-        parameters.dW[s] += coefficient * (
-            np.dot(
-                cache.dA_prime[s][:, j, :]
-                * cache.G_prime_prime[s]
-                * cache.Z_prime[s][:, j, :],
-                cache.A[r].T,
-            )
-            + np.dot(
-                cache.dA_prime[s][:, j, :] * cache.G_prime[s],
-                cache.A_prime[r][:, j, :].T,
-            )
-        )
-        parameters.db[s] += coefficient * np.sum(
-            cache.dA_prime[s][:, j, :]
-            * cache.G_prime_prime[s]
-            * cache.Z_prime[s][:, j, :],
-            axis=1,
-            keepdims=True,
-        )
-        cache.dA[r] += np.dot(
-            parameters.W[s].T,
-            cache.dA_prime[s][:, j, :]
-            * cache.G_prime_prime[s]
-            * cache.Z_prime[s][:, j, :],
-        )
-        cache.dA_prime[r][:, j, :] = np.dot(
-            parameters.W[s].T,
-            cache.dA_prime[s][:, j, :] * cache.G_prime[s],
-        )
+    # Vectorized over the n_x partials. The two intermediates below are the
+    # per-partial products that the original Python loop recomputed each pass;
+    # every contraction now delegates to a single BLAS-backed dot/tensordot.
+    t1 = cache.dA_prime[s] * cache.G_prime_prime[s][:, np.newaxis, :] * cache.Z_prime[s]
+    t2 = cache.dA_prime[s] * cache.G_prime[s][:, np.newaxis, :]
+    # A[r] carries no partial (j) axis, so t1 can be summed over j before the dot.
+    t1_sum_j = t1.sum(axis=1)  # (n_s, m)
+    parameters.dW[s] += coefficient * (
+        np.dot(t1_sum_j, cache.A[r].T)
+        + np.tensordot(t2, cache.A_prime[r], axes=([1, 2], [1, 2]))
+    )
+    parameters.db[s] += coefficient * t1_sum_j.sum(axis=1, keepdims=True)
+    cache.dA[r] += np.dot(parameters.W[s].T, t1_sum_j)
+    cache.dA_prime[r][:] = np.tensordot(parameters.W[s].T, t2, axes=([1], [0]))
 
 
 def model_backward(

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -171,4 +171,76 @@ class TestXOR:
         assert _grad_check(dydx, dydx_FD)
 
 
-# TODO: add test(s) for gradient-enhanced backprop and forward prop of partials
+class TestGradientEnhanced:
+    """Check gradient-enhanced backprop for a multi-input problem (n_x >= 2).
+
+    The regular finite-difference gradient check guards the standard backprop,
+    but only ever exercises n_x = 1 (the 1D sinusoid). This class covers the
+    ``for j in range(n_x)`` paths in ``next_layer_partials`` and
+    ``gradient_enhancement`` with n_x = 2, so their vectorized forms stay
+    numerically faithful.
+    """
+
+    @pytest.fixture
+    def data(self) -> jenn.core.data.Dataset:
+        """Return a small 2-input quadratic dataset with exact Jacobian.
+
+        y = x0^2 + x1^2  =>  dy/dx0 = 2 x0,  dy/dx1 = 2 x1
+        """
+        rng = np.random.default_rng(0)
+        X = rng.standard_normal((2, 5))  # (n_x, m)
+        Y = np.sum(X**2, axis=0, keepdims=True)  # (n_y, m)
+        J = np.zeros((1, 2, 5))  # (n_y, n_x, m)
+        J[0, 0, :] = 2 * X[0, :]
+        J[0, 1, :] = 2 * X[1, :]
+        return jenn.core.data.Dataset(X, Y, J)
+
+    @pytest.fixture
+    def cache(self) -> jenn.core.cache.Cache:
+        """Return cache sized to the 2-input dataset."""
+        return jenn.core.cache.Cache(layer_sizes=[2, 3, 1], m=5)
+
+    @pytest.fixture
+    def params(self) -> jenn.core.parameters.Parameters:
+        """Return randomly initialized parameters (tanh hidden layer).
+
+        A tanh hidden layer is used deliberately so the second derivative
+        (``G_prime_prime``) is non-zero and the gradient-enhancement terms
+        are fully exercised.
+        """
+        parameters = jenn.core.parameters.Parameters(
+            layer_sizes=[2, 3, 1],
+            hidden_activation="tanh",
+            output_activation="linear",
+        )
+        parameters.initialize(random_state=1)
+        return parameters
+
+    def test_gradient_enhanced_backward(
+        self,
+        data: jenn.core.data.Dataset,
+        params: jenn.core.parameters.Parameters,
+        cache: jenn.core.cache.Cache,
+    ) -> None:
+        """Check gradient-enhanced backprop against finite difference (n_x=2)."""
+        jenn.core.propagation.model_partials_forward(data.X, params, cache)
+        jenn.core.propagation.model_backward(data, params, cache)
+
+        def cost_finite_diff(x):
+            parameters = deepcopy(params)  # make copy b/c arrays updated in place
+            cost = jenn.core.cost.Cost(data, parameters)
+            parameters.unstack(x)
+            Y_pred, J_pred = jenn.core.propagation.model_partials_forward(
+                data.X,
+                parameters,
+                deepcopy(cache),
+            )
+            return cost.evaluate(Y_pred, J_pred)
+
+        dydx = params.stack_partials_per_layer()
+        dydx_FD = _finite_difference(cost_finite_diff, params.stack_per_layer())
+
+        assert _grad_check(dydx, dydx_FD)
+
+
+# TODO: add test(s) for forward prop of partials


### PR DESCRIPTION
## Summary

Closes #39. Vectorizes the two Python `for j in range(n_x)` loops in JENN's training hot path into single BLAS-backed tensor contractions, and removes per-iteration temporary allocations in the backward pass, activation derivatives, and cost function.

This PR implements the **low-risk subset** of the ticket plus one bonus vectorization. It deliberately **excludes**:

- **Item #3** (reuse `Cache`/`Cost` across batches) — batch sizes are ragged and `Cost` binds to per-batch arrays that change each epoch; unsafe to reuse naively.
- **Item #4** (persistent `stack_partials` buffer) — would break ADAM's new-search-direction detection, which relies on `self._grads is not grads` object identity.
- **Item #9** (mini-batch zero-copy) — once-per-epoch (not hot) and changes shuffle semantics for marginal gain.

## Changes

**Perf**
- `propagation.py`: `next_layer_partials` and `gradient_enhancement` vectorized with `np.tensordot` (also removes a matmul that was computed twice per iteration); input-layer identity partial written in place via broadcasting (drops `eye()` and its per-pass `(n_x, n_x, m)` allocation); `g'(z)·dA` computed once into a reused cache buffer in `next_layer_backward` (was computed 3×).
- `cost.py`: `SquaredLoss.evaluate` / `GradientEnhancement.evaluate` `n_y`/`n_x` Python loops replaced with `np.sum(np.square(...))`.
- `activation.py`: `Tanh`/`Relu` `first_derivative` made fully in place.
- `cache.py`: added `dZ` scratch buffer.

**Test / tooling**
- `test_propagation.py`: **new finite-difference gradient check for gradient-enhanced backprop with `n_x >= 2`** — previously *no* test exercised the `n_x` loop for `n_x > 1` (all tests were 1D; `TestRastrigin` was stubbed). This is the correctness gate for the vectorization.
- `scripts/benchmark.py` + `benchmark` pixi task + committed `benchmark_results.json` baseline.
- `notebooks/runtime.ipynb`: updated to the current API (was calling the pre-`v2.0.0` `jenn.synthetic.Rastrigin.sample`, breaking the notebook test suite).

## Performance report

Measured on macOS (arm64, numpy 2.5.1); baseline captured on the pre-change code, both stored in `benchmark_results.json`.

| Benchmark | Baseline | This PR | Speedup |
|---|---|---|---|
| `gradient_enhancement` (micro, n_x=16, m=5000) | 7.89 ms | 4.66 ms | **1.69×** |
| `next_layer_partials` (micro, n_x=16, m=5000) | 2.75 ms | 1.60 ms | **1.72×** |
| **Airfoil train, end-to-end** (n_x=16, m=42039) | **20.66 s** | **12.84 s** | **1.61× (≈38% faster)** |

The gain scales with `n_x` and `m`, so multi-input problems (like the 16-input airfoil case) benefit most; 1D problems are essentially unchanged.

### Note on `tensordot` vs `einsum`
A naive `np.einsum(...)` without `optimize=True` benchmarked **~4× slower than the original loop** (it doesn't dispatch to BLAS). `np.tensordot` was chosen for guaranteed, version-stable BLAS dispatch.

## Verification
- **21/21 unit tests pass** on both `py39` (oldest supported) and `py3.14`.
- Lint clean: `ruff` + `mypy` + `docformatter`.
- Vectorized forms verified numerically equivalent to the original loops (max abs diff ~5.7e-14, far below the test tolerance `atol=1e-6`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
