### PR TITLE
Harden the release pipeline: pre-publish gates, Trusted Publishing, smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: ['*']
   pull_request:
+  workflow_call:  # allow release.yml to reuse these jobs as a gate
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,25 @@ on:
     tags: ['v*']
 
 jobs:
+  # Gate: run the full lint + test matrix (py39–py314) on the tagged commit.
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  # Gate: the pushed tag must match src/jenn/__init__.py's __version__.
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Assert tag matches __version__
+        run: |
+          VERSION=$(grep -oP '__version__ = "\K[^"]+' src/jenn/__init__.py)
+          TAG=${GITHUB_REF_NAME#v}
+          echo "tag=$TAG __version__=$VERSION"
+          [ "$VERSION" = "$TAG" ] || { echo "::error::tag $TAG != __version__ $VERSION"; exit 1; }
+
   build-dist:
+    needs: [ci, check-version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +38,13 @@ jobs:
       - name: Build distribution files
         run: pixi run -e dev build
 
+      - name: Smoke-test the built wheel
+        run: |
+          VER=${GITHUB_REF_NAME#v}
+          python3 -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install ./build/dist/*.whl
+          /tmp/smoke/bin/python -c "import jenn; assert jenn.__version__ == '$VER', jenn.__version__; print('ok', jenn.__version__)"
+
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4
         with:
@@ -31,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:
-      id-token: write
+      id-token: write  # Trusted Publishing (OIDC) — no API token
     steps:
       - name: Download dist artifact
         uses: actions/download-artifact@v4
@@ -45,15 +70,35 @@ jobs:
           verbose: true
           skip-existing: true
           repository-url: https://test.pypi.org/legacy/
-          user: __token__
-          password: ${{ secrets.TESTPYPI_TOKEN }}
+
+  # Gate: install the just-published package from TestPyPI and import it,
+  # before it can reach real PyPI. Runtime deps come from real PyPI; retry to
+  # absorb TestPyPI index-propagation lag.
+  smoke-testpypi:
+    needs: publish-testpypi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install from TestPyPI and import
+        run: |
+          VER=${GITHUB_REF_NAME#v}
+          for i in 1 2 3 4 5; do
+            pip install --index-url https://test.pypi.org/simple/ \
+                        --extra-index-url https://pypi.org/simple/ "jenn==$VER" && break
+            echo "attempt $i failed, retrying in 15s (TestPyPI index lag)…"
+            sleep 15
+          done
+          python -c "import jenn; assert jenn.__version__ == '$VER', jenn.__version__; print('ok', jenn.__version__)"
 
   publish-pypi:
-    needs: publish-testpypi
+    needs: smoke-testpypi
     runs-on: ubuntu-latest
     environment: pypi  # requires manual approval — configure in Settings → Environments
     permissions:
-      id-token: write
+      id-token: write  # Trusted Publishing (OIDC) — no API token
     steps:
       - name: Download dist artifact
         uses: actions/download-artifact@v4
@@ -66,8 +111,6 @@ jobs:
         with:
           verbose: true
           skip-existing: true
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 
   github-release:
     needs: publish-pypi
@@ -76,6 +119,8 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download dist artifact
         uses: actions/download-artifact@v4
         with:
@@ -89,6 +134,13 @@ jobs:
             ./dist/*.tar.gz
             ./dist/*.whl
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          awk -v ver="${GITHUB_REF_NAME#v}" '
+            $0 ~ "^## v"ver {flag=1; next} flag && /^## / {exit} flag {print}
+          ' CHANGELOG.md > release-notes.md
+          echo "--- release notes ---"; cat release-notes.md
+
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -96,7 +148,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          --notes ""
+          --notes-file release-notes.md
 
       - name: Upload signatures to GitHub Release
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ build: Changes to the build process or tools.
 - Resolved CI lint failures from `ruff` 0.15 rule changes
 - Added `[tool.docformatter]` config (`wrap-summaries = 0`) to stop RST module-docstring headers from being collapsed into the summary line
 - Fixed multi-line `pixi` task commands (`test-unit`, `sphinx`, `fix-toml`) whose arguments were being split into separate shell commands by newlines
+- Hardened the `release` workflow: gate on the full CI matrix (via `ci.yml`
+  `workflow_call`) and a tag/`__version__` consistency check before any publish
+- Added a local-wheel smoke test (install + import in a clean venv) in `build-dist`,
+  plus a TestPyPI round-trip install/import gate before the PyPI publish
+- Switched PyPI/TestPyPI publishing to Trusted Publishing (OIDC), removing stored
+  API tokens
+- Release notes are now populated automatically from `CHANGELOG.md` instead of
+  being empty
 
 ## v2.0.0 (2025-12-06)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,25 @@ pixi run lab
 
 A new release is created by pushing a new tag to the remote (e.g. `v1.0.9`). This triggers a __test-build-deploy__ workflow that publishes to `pypi.org`, `GitHub Pages` and `Github Release`. Tag pattern must be `v*`.
 
+Before anything is published, the release pipeline runs two gates on the tagged commit:
+
+- the **full CI matrix** (lint + unit tests on py39–py314, reused from `ci.yml`), and
+- a **tag/version check** — the tag (minus its `v`) must equal `__version__` in
+  `src/jenn/__init__.py`, or the release fails fast.
+
+It then publishes to TestPyPI and **smoke-installs the package from TestPyPI and imports it**
+before the real PyPI publish. The PyPI publish sits behind the `pypi` GitHub Environment's
+manual-approval gate. GitHub Release notes are filled automatically from the matching
+`## v<version>` section of `CHANGELOG.md`.
+
 ### Prerequisites
 
-Either [pypi](https://pypi.org/) and [testpypi](https://test.pypi.org/) need to be setup for [trusted publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/) or Github must be provided an [API token](https://pypi.org/help/#apitoken) to enable communication between these servers. Currently, the latter is used.
+Both [pypi](https://pypi.org/) and [testpypi](https://test.pypi.org/) are configured for
+[trusted publishing](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)
+(OIDC) — no API tokens are stored. Each trusted publisher is bound to this repo, the
+`release.yml` workflow, and the matching GitHub Environment (`pypi` / `testpypi`); the
+environment name in the publisher config must exactly match the `environment:` on the
+corresponding job.
 
 ### Mock Release
 


### PR DESCRIPTION
## Why

The tag-triggered release (`.github/workflows/release.yml`) went straight from tag push to PyPI with almost nothing in the way:

- **No test/lint gate.** A tag push is a *separate event* from `ci.yml` (which only ran on branch/PR pushes), so a tag on an untested or broken commit published to PyPI. PyPI is immutable — one bad tag permanently burns the version number.
- **Tag ↔ version could silently diverge.** `__version__` is hand-edited in `src/jenn/__init__.py` and nothing asserted it matched the pushed tag, so you could ship a wheel labelled `2.0.0` under a `v2.0.1` release.
- **Long-lived API tokens.** The publish jobs already declared `id-token: write` + environments (90% of the OIDC setup) but still passed `password: ${{ secrets.*_TOKEN }}` — a rotating secret and leak vector for no benefit.
- **TestPyPI hard-blocked prod but proved nothing.** `publish-pypi` needed `publish-testpypi`, yet nothing ever installed from TestPyPI — so it was a failure point that added no safety.
- **Empty release notes.** `gh release create ... --notes ""` produced a blank GitHub Release body every time.

## What changed

Four gates now stand between a tag and PyPI, and publishing no longer uses stored tokens.

### 1. Reuse the full CI matrix as a gate (`ci.yml`)

`ci.yml` becomes callable so the release reuses the exact same lint + py39–py314 jobs — no duplicated matrix:

```yaml
on:
  push:
    branches: ['*']
  pull_request:
  workflow_call:  # allow release.yml to reuse these jobs as a gate
```

```yaml
# release.yml
jobs:
  ci:
    uses: ./.github/workflows/ci.yml   # gates everything below
```

### 2. Fail fast if the tag doesn't match `__version__`

Runs in parallel with CI; a mismatch stops the release before anything is built:

```yaml
  check-version:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Assert tag matches __version__
        run: |
          VERSION=$(grep -oP '__version__ = "\K[^"]+' src/jenn/__init__.py)
          TAG=${GITHUB_REF_NAME#v}
          [ "$VERSION" = "$TAG" ] || { echo "::error::tag $TAG != __version__ $VERSION"; exit 1; }
```

```yaml
  build-dist:
    needs: [ci, check-version]
```

### 3. Two smoke gates — the artifact must install *and* import

**Local wheel** (authoritative — tests the exact bytes headed to PyPI, before any upload):

```yaml
      - name: Smoke-test the built wheel
        run: |
          VER=${GITHUB_REF_NAME#v}
          python3 -m venv /tmp/smoke
          /tmp/smoke/bin/pip install ./build/dist/*.whl
          /tmp/smoke/bin/python -c "import jenn; assert jenn.__version__ == '$VER', jenn.__version__; print('ok', jenn.__version__)"
```

**TestPyPI round-trip** (validates the upload → index → download path; runtime deps come from real PyPI, with retries for TestPyPI index-propagation lag):

```yaml
  smoke-testpypi:
    needs: publish-testpypi
    steps:
      - uses: actions/setup-python@v5
        with: { python-version: '3.12' }
      - name: Install from TestPyPI and import
        run: |
          VER=${GITHUB_REF_NAME#v}
          for i in 1 2 3 4 5; do
            pip install --index-url https://test.pypi.org/simple/ \
                        --extra-index-url https://pypi.org/simple/ "jenn==$VER" && break
            sleep 15
          done
          python -c "import jenn; assert jenn.__version__ == '$VER'; print('ok', jenn.__version__)"
```

### 4. Trusted Publishing (OIDC) — no more tokens

The `user`/`password` lines are gone from both publish jobs; environments + `id-token: write` remain:

```yaml
  publish-pypi:
    needs: smoke-testpypi
    environment: pypi           # manual-approval gate (Required reviewers)
    permissions:
      id-token: write           # Trusted Publishing — no API token
    steps:
      - uses: actions/download-artifact@v4
        with: { name: dist, path: ./dist }
      - uses: pypa/gh-action-pypi-publish@release/v1
        with:
          verbose: true
          skip-existing: true
```

### 5. Release notes from `CHANGELOG.md`

`github-release` now checks out the repo and extracts the matching section instead of shipping an empty body:

```yaml
      - name: Extract release notes from CHANGELOG
        run: |
          awk -v ver="${GITHUB_REF_NAME#v}" '
            $0 ~ "^## v"ver {flag=1; next} flag && /^## / {exit} flag {print}
          ' CHANGELOG.md > release-notes.md
      - name: Create GitHub Release
        run: gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes-file release-notes.md
```

## Resulting pipeline

```
tag v* ──► ci (lint + py39–py314) ─┐
           check-version ──────────┴─► build-dist ─► smoke (local wheel)
                                                   └─► publish-testpypi ─► smoke-testpypi
                                                                        └─► publish-pypi (manual approval)
                                                                                        └─► github-release (CHANGELOG notes + Sigstore)
```

## Not covered here (deliberately)

- Version bumping stays **manual** (`src/jenn/__init__.py`), now guarded by `check-version`. `setuptools-scm` / release-please were considered but are out of scope for this "minimal" pass.
- `skip-existing: true` is kept on both publishes for idempotent re-runs; the local-wheel smoke removes the staleness concern that flag would otherwise introduce.

## Required setup before the next release

- [ ] Trusted publishers configured on PyPI + TestPyPI (owner `shb84`, repo `JENN`, workflow `release.yml`, environments `pypi` / `testpypi`) — **done**
- [ ] Create the `pypi` GitHub Environment **with Required reviewers** (the manual-approval gate is *not* created just by naming `environment: pypi` in YAML)
- [ ] Create the `testpypi` GitHub Environment
- [ ] Merge this PR, then tag the merge commit (the workflow that runs is the one *at the tagged commit*)
- [ ] Optionally delete the now-unused `PYPI_TOKEN` / `TESTPYPI_TOKEN` secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)