### PR TITLE
Reuse a saved model: add load_model and predict to the MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,10 +66,13 @@ todo.txt
 *.doit.db.db
 *.doit.db
 
-# Local environments 
+# Local plans / scratch (never committed)
+.tmp/
+
+# Local environments
 .envs
-.env 
-.venv 
+.env
+.venv
 
 # Specific files 
 docs/examples/parameters.json 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,14 @@ build: Changes to the build process or tools.
   columns / array names) to `ingest`, and exported model JSONs (with
   `layer_sizes`) to load — so a user can discover files by reference instead of
   pasting paths.
+- Extended the MCP server with `load_model` and `predict` tools, closing the
+  reuse loop: in a fresh session an agent can `load_model` a previously
+  `export`ed JSON and `predict` on new inputs (inline, or from a CSV/NPZ file
+  via `path`), optionally returning the Jacobian and optionally writing results
+  to a file (`output_path`) for large runs. Added
+  `jenn.utilities.load_csv_inputs` and `jenn.utilities.load_npz_inputs`, the
+  inputs-only counterparts of `load_csv`/`load_npz`, so new prediction inputs
+  never have to be hand-assembled or pasted into context.
 
 ### Fix
 
@@ -63,6 +71,11 @@ build: Changes to the build process or tools.
   used the pre-`v2.0.0` `jenn.utils` / `.evaluate` / `r_square`), so they run
   again. Fixed `demo_4_rosenbrock.ipynb` to pass scalar coordinates to
   matplotlib's `annotate` (size-1 arrays now raise under current NumPy).
+- Documented the MCP file-orientation convention in the README and `predict`
+  docstring: on disk a `.csv` is a row-per-sample table while a `.npz` is
+  feature-first (`(n_x, m)`, the core axis order), the transpose of the inline
+  row-per-sample MCP arrays — each channel matching the format its producer
+  naturally emits.
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,16 @@ row-is-a-sample convention that agents and tabular data most naturally produce,
 and transposes internally — so the difference is intentional, not an
 inconsistency.
 
+Files, however, keep each format's **native** orientation, not the inline
+row-per-sample one. A `.csv` is a row-per-sample table (what a spreadsheet
+exports, and what `ingest`/`load_csv` read); a `.npz` is feature-first — `x` of
+shape `(n_x, m)` — matching `jenn.utilities.load_npz` and the core arrays. So an
+`.npz` you hand to `predict`, or receive from it via `output_path`, uses the core
+axis order (`(n_x, m)`), the transpose of the inline MCP arrays. Each channel
+matches the convention its producer most naturally emits — hand-authored
+JSON is row-per-sample, machine-written array files are feature-first — which
+avoids forcing either side to reshape.
+
 # Use Case
 
 JENN is intended for the field of computer aided design, where there is often 

--- a/src/jenn/mcp/_convert.py
+++ b/src/jenn/mcp/_convert.py
@@ -98,3 +98,34 @@ def prepare_training_data(
             msg = f"`dydx` has {partials.shape[2]} samples but `x` has {m}."
             raise ValueError(msg)
     return inputs, outputs, partials
+
+
+def to_row_per_sample(values: np.ndarray) -> list[list[float]]:
+    r"""Convert a feature-first array back to a row-per-sample matrix.
+
+    The inverse of :func:`to_feature_first`, used to return model output
+    over the MCP boundary. Consumes trusted feature-first arrays
+    produced by :mod:`jenn` (unlike the inbound helpers, no validation
+    is needed).
+
+    :param values: shape ``(n, m)`` -- ``n`` features over ``m`` samples
+        (e.g. ``y`` as ``(n_y, m)``)
+    :return: nested list of shape ``(m, n)`` -- ``m`` samples of ``n``
+        features
+    """
+    return values.T.tolist()
+
+
+def to_row_per_sample_partials(values: np.ndarray) -> list[list[list[float]]]:
+    r"""Convert feature-first Jacobians back to row-per-sample form.
+
+    The inverse of :func:`to_feature_first_partials`, used to return model
+    partials over the MCP boundary. Consumes trusted feature-first arrays
+    produced by :mod:`jenn` (unlike the inbound helpers, no validation is
+    needed).
+
+    :param values: shape ``(n_y, n_x, m)`` -- feature-first Jacobians
+    :return: nested list of shape ``(m, n_y, n_x)`` -- one Jacobian per
+        sample (rows = outputs, cols = inputs)
+    """
+    return np.transpose(values, (2, 0, 1)).tolist()

--- a/src/jenn/mcp/_store.py
+++ b/src/jenn/mcp/_store.py
@@ -34,15 +34,18 @@ class ModelRecord(Record):
 
     model: NeuralNet
     layer_sizes: list[int]
-    hyperparameters: dict[str, Any]
-    random_state: int | None
-    x: np.ndarray  # feature-first training inputs  (n_x, m)
-    y: np.ndarray  # feature-first training outputs (n_y, m)
-    dydx: np.ndarray | None  # feature-first Jacobians (n_y, n_x, m) or None
+    hyperparameters: dict[str, Any] = field(default_factory=dict)
+    random_state: int | None = None
+    x: np.ndarray | None = None  # feature-first training inputs  (n_x, m)
+    y: np.ndarray | None = None  # feature-first training outputs (n_y, m)
+    dydx: np.ndarray | None = None  # feature-first Jacobians (n_y, n_x, m) or None
     training_seconds: float  # wall-clock time spent in NeuralNet.fit
     partial_mask: np.ndarray | None = None  # (n_y, n_x) availability mask or None
     input_names: list[str] | None = None  # column names for inputs, if known
     output_names: list[str] | None = None  # column names for outputs, if known
+    source: str | None = (
+        None  # provenance, e.g. the ingested file path (if model reloaded)
+    )
 
 
 @dataclass(kw_only=True)

--- a/src/jenn/mcp/server.py
+++ b/src/jenn/mcp/server.py
@@ -19,9 +19,14 @@ import numpy as np
 
 from jenn.core.model import NeuralNet
 from jenn.post_processing.metrics import rsquare
-from jenn.utilities import load_csv, load_npz
+from jenn.utilities import load_csv, load_csv_inputs, load_npz, load_npz_inputs
 
-from ._convert import prepare_training_data
+from ._convert import (
+    prepare_training_data,
+    to_feature_first,
+    to_row_per_sample,
+    to_row_per_sample_partials,
+)
 from ._store import DatasetRecord, ModelRecord, Registry
 
 try:
@@ -405,16 +410,22 @@ def evaluate(
         mask = None  # inline partials are all present as given
         dataset = "holdout"
         if (inputs.shape[0], outputs.shape[0]) != (
-            record.x.shape[0],
-            record.y.shape[0],
+            record.layer_sizes[0],
+            record.layer_sizes[-1],
         ):
             msg = (
                 "Data shape mismatch: model expects (n_inputs, n_outputs) = "
-                f"({record.x.shape[0]}, {record.y.shape[0]}), got "
+                f"({record.layer_sizes[0]}, {record.layer_sizes[-1]}), got "
                 f"({inputs.shape[0]}, {outputs.shape[0]})."
             )
             raise ValueError(msg)
     elif x is None and y is None:
+        if record.x is None or record.y is None:
+            msg = (
+                "This model was loaded from disk and carries no training data to "
+                "score. Provide holdout x and y, or a dataset_id."
+            )
+            raise ValueError(msg)
         inputs, outputs, partials = record.x, record.y, record.dydx
         dataset = "training"
     else:
@@ -474,10 +485,11 @@ def list_models() -> dict[str, Any]:
         {
             "model_id": handle,
             "layer_sizes": record.layer_sizes,
-            "n_samples": int(record.x.shape[1]),
+            "n_samples": None if record.x is None else int(record.x.shape[1]),
             "random_state": record.random_state,
             "training_seconds": round(record.training_seconds, 4),
             "hyperparameters": record.hyperparameters,
+            "source": record.source,
         }
         for handle, record in _MODELS.items()
     ]
@@ -602,6 +614,179 @@ def list_datasets() -> dict[str, Any]:
         for handle, record in _DATASETS.items()
     ]
     return {"count": len(datasets), "datasets": datasets}
+
+
+# ----------------------------------------------------------
+# --- MODEL REUSE (LOAD & PREDICT) -------------------------
+# ----------------------------------------------------------
+
+
+@mcp.tool()
+def load_model(path: str) -> dict[str, Any]:
+    """Load a saved JENN model from disk and register it for reuse.
+
+    The disk->registry direction (mirrors `ingest` for datasets): wraps
+    `jenn.NeuralNet.load`, so a model trained and `export`ed in an
+    earlier session can be reloaded in a fresh one and run with
+    `predict`. The returned model is data-less (a saved model carries
+    only weights and normalization, no training data), so `evaluate` on
+    it needs holdout data or a `dataset_id`. Returns the `model_id` plus
+    lightweight metadata (`source`, `layer_sizes`, `n_inputs`,
+    `n_outputs`).
+    """
+    target = Path(path).expanduser().resolve()
+    if not target.is_file():
+        msg = f"No such file: {target}"
+        raise ValueError(msg)
+    data = json.loads(target.read_text(encoding="utf-8"))
+    if not (isinstance(data, dict) and {"layer_sizes", "W", "b"} <= data.keys()):
+        msg = f"`{target}` is not a valid JENN model file."
+        raise ValueError(msg)
+    model = NeuralNet.load(target)
+    layer_sizes = model.parameters.layer_sizes
+    handle = _MODELS.add(
+        ModelRecord(
+            model=model,
+            layer_sizes=layer_sizes,
+            training_seconds=0.0,
+            source=str(target),
+        ),
+    )
+    return {
+        "model_id": handle,
+        "source": str(target),
+        "layer_sizes": layer_sizes,
+        "n_inputs": layer_sizes[0],
+        "n_outputs": layer_sizes[-1],
+        "note": (
+            "Data-less model (weights + normalization only). Run it with "
+            "`predict`; to `evaluate` it, supply holdout x/y or a dataset_id."
+        ),
+    }
+
+
+def _resolve_predict_inputs(
+    x: list[list[float]] | None,
+    path: str | None,
+    inputs: list[str] | None,
+    delimiter: str,
+) -> np.ndarray:
+    """Resolve inline ``x`` or a CSV/NPZ ``path`` to feature-first inputs.
+
+    ``x`` and ``path`` are mutually exclusive. A ``.csv`` path needs an
+    ``inputs`` column list; a ``.npz`` path reads its feature-first
+    ``x`` array.
+
+    :return: feature-first inputs of shape ``(n_x, m)``
+    """
+    if x is not None and path is not None:
+        msg = "Provide either inline x or a file path, not both."
+        raise ValueError(msg)
+    if x is not None:
+        return to_feature_first(x, "x")
+    if path is None:
+        msg = "Provide inline x or a file path."
+        raise ValueError(msg)
+    target = Path(path).expanduser().resolve()
+    if not target.is_file():
+        msg = f"No such file: {target}"
+        raise ValueError(msg)
+    kind = target.suffix.lstrip(".").lower()
+    if kind == "csv":
+        if not inputs:
+            msg = "CSV input requires an `inputs` column list."
+            raise ValueError(msg)
+        return load_csv_inputs(target, inputs, delimiter)
+    if kind == "npz":
+        return load_npz_inputs(target)
+    msg = f"Unsupported input format '{kind}'; expected 'csv' or 'npz'."
+    raise ValueError(msg)
+
+
+def _write_predictions(
+    output_path: str,
+    inputs_ff: np.ndarray,  # feature-first (n_x, m)
+    y_ff: np.ndarray,  # feature-first (n_y, m)
+    dydx_ff: np.ndarray | None,  # feature-first (n_y, n_x, m) or None
+    delimiter: str,
+) -> dict[str, Any]:
+    """Write predictions to a file, feature-first (matching the loaders).
+
+    ``.npz`` holds ``x``/``y`` (plus ``dydx`` when partials were
+    requested); ``.csv`` holds the response columns only (partials
+    require ``.npz``).
+
+    :return:``{"path": ..., "n_samples": ...}``
+    """
+    out = Path(output_path).expanduser().resolve()
+    kind = out.suffix.lstrip(".").lower()
+    if kind == "npz":
+        arrays = {"x": inputs_ff, "y": y_ff}
+        if dydx_ff is not None:
+            arrays["dydx"] = dydx_ff
+        np.savez(out, **arrays)
+    elif kind == "csv":
+        if dydx_ff is not None:
+            msg = "CSV output holds response columns only; use .npz to write partials."
+            raise ValueError(msg)
+        rows = to_row_per_sample(y_ff)  # (m, n_y)
+        header = [f"y{i}" for i in range(y_ff.shape[0])]
+        with out.open("w", newline="", encoding="utf-8") as file:
+            writer = csv.writer(file, delimiter=delimiter)
+            writer.writerow(header)
+            writer.writerows(rows)
+    else:
+        msg = f"Unsupported output format '{kind}'; expected 'csv' or 'npz'."
+        raise ValueError(msg)
+    return {"path": str(out), "n_samples": int(inputs_ff.shape[1])}
+
+
+@mcp.tool()
+def predict(
+    model_id: str,
+    x: list[list[float]] | None = None,
+    path: str | None = None,
+    inputs: list[str] | None = None,
+    delimiter: str = ",",
+    with_partials: bool = False,
+    output_path: str | None = None,
+) -> dict[str, Any]:
+    """Run a trained model on new inputs, optionally returning the Jacobian.
+
+    Supply inputs either inline (row-per-sample `x`=(m, n_x)) OR by file
+    `path` (mutually exclusive): a `.csv` (a row-per-sample table, with
+    an `inputs` column list) or a `.npz` holding a feature-first array
+    `x` of shape `(n_x, m)` -- the core axis order, the transpose of the
+    inline arrays. The input width must match the model's `n_inputs`.
+    With `with_partials`, the response also includes `dydx` (row-per-
+    sample (m, n_y, n_x)). By default results are returned inline; give
+    `output_path` (`.csv` or `.npz`) to write them to a file instead
+    (for large runs) -- the inline arrays are then omitted. A `.csv`
+    output is a row-per-sample table of the response columns only; a
+    `.npz` is feature-first (`x`/`y`/`dydx`) and persists partials.
+    """
+    record = _MODELS.get(model_id)  # raises KeyError on unknown id
+    inputs_ff = _resolve_predict_inputs(x, path, inputs, delimiter)
+
+    n_x = record.layer_sizes[0]
+    if inputs_ff.shape[0] != n_x:
+        msg = f"Input width {inputs_ff.shape[0]} does not match model n_inputs {n_x}."
+        raise ValueError(msg)
+
+    if with_partials:
+        y_ff, dydx_ff = record.model(inputs_ff)  # (n_y, m), (n_y, n_x, m)
+    else:
+        y_ff = record.model.predict(inputs_ff)  # (n_y, m)
+        dydx_ff = None
+
+    if output_path is not None:
+        written = _write_predictions(output_path, inputs_ff, y_ff, dydx_ff, delimiter)
+        return {"model_id": model_id, **written}
+
+    result: dict[str, Any] = {"model_id": model_id, "y": to_row_per_sample(y_ff)}
+    if dydx_ff is not None:
+        result["dydx"] = to_row_per_sample_partials(dydx_ff)
+    return result
 
 
 # ----------------------------------------------------------

--- a/src/jenn/utilities/__init__.py
+++ b/src/jenn/utilities/__init__.py
@@ -3,8 +3,17 @@
 
 from ._finite_difference import finite_difference
 from ._jmp import from_jmp
-from ._load import load_csv, load_npz
+from ._load import load_csv, load_csv_inputs, load_npz, load_npz_inputs
 from ._rbf import rbf
 from ._sample import sample
 
-__all__ = ["finite_difference", "from_jmp", "load_csv", "load_npz", "rbf", "sample"]
+__all__ = [
+    "finite_difference",
+    "from_jmp",
+    "load_csv",
+    "load_csv_inputs",
+    "load_npz",
+    "load_npz_inputs",
+    "rbf",
+    "sample",
+]

--- a/src/jenn/utilities/_load.py
+++ b/src/jenn/utilities/_load.py
@@ -221,3 +221,49 @@ def load_npz(
     mask = (~missing).astype(float)
     dydx = np.where(is_nan, 0.0, dydx)  # finite placeholder for absent partials
     return x, y, dydx, mask
+
+
+def load_csv_inputs(
+    path: str | Path,
+    inputs: list[str],
+    delimiter: str = ",",
+) -> np.ndarray:
+    r"""Load inputs-only data from a wide, one-row-per-sample CSV file.
+
+    The inputs-only counterpart of :func:`load_csv`, for running a
+    trained model on new data (which has no outputs or derivatives).
+    ``inputs`` names the value columns to read, in the desired order;
+    roles are set by explicit mapping, never by a naming convention.
+
+    :param path: path to the CSV file
+    :param inputs: column names mapped to ``x``, in order
+    :param delimiter: field separator (e.g. ``","`` or ``";"``)
+    :return: feature-first array ``x`` of shape ``(n_x, m)``
+    """
+    path = Path(path).expanduser()
+    columns = _read_columns(path, delimiter)
+    return _stack(columns, inputs, "input", path)  # (n_x, m)
+
+
+def load_npz_inputs(path: str | Path) -> np.ndarray:
+    r"""Load inputs-only data from a ``.npz`` file.
+
+    The inputs-only counterpart of :func:`load_npz`, for running a
+    trained model on new data. The archive must hold an array named
+    ``x`` ``(n_x, m)``, consumed as-is; any ``y`` or ``dydx`` present is
+    ignored.
+
+    :param path: path to the ``.npz`` file
+    :return: feature-first array ``x`` of shape ``(n_x, m)``
+    """
+    path = Path(path).expanduser()
+    with np.load(path) as archive:
+        key = "x"
+        if key not in archive:
+            msg = f"`{path}` has no array named '{key}'."
+            raise ValueError(msg)
+        x = np.asarray(archive["x"], dtype=float)
+        if x.ndim != 2:
+            msg = f"`x` in `{path}` must be a 2-D feature-first array; got x.ndim={x.ndim}."
+            raise ValueError(msg)
+        return x

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from jenn.utilities import load_csv, load_npz
+from jenn.utilities import load_csv, load_csv_inputs, load_npz, load_npz_inputs
 
 DATA = Path(__file__).parent / "data"
 
@@ -94,3 +94,52 @@ def test_load_npz_rejects_partial_nan(tmp_path):
     np.savez(path, x=np.zeros((2, 4)), y=np.zeros((1, 4)), dydx=dydx)
     with pytest.raises(ValueError, match="only some samples"):
         load_npz(path)
+
+
+def test_load_csv_inputs_matches_load_csv():
+    """Inputs-only CSV read returns the same feature-first x as load_csv."""
+    x = load_csv_inputs(DATA / "rastrigin.csv", inputs=["x1", "x2"])
+    assert x.shape == (2, 100)  # feature-first (n_x, m)
+    x_full, *_ = load_csv(DATA / "rastrigin.csv", inputs=["x1", "x2"], outputs=["y"])
+    assert np.allclose(x, x_full)  # identical array, not a transpose
+
+
+def test_load_csv_inputs_unknown_column():
+    """An input column absent from the file raises ValueError."""
+    with pytest.raises(ValueError, match="not found"):
+        load_csv_inputs(DATA / "rastrigin.csv", inputs=["nope"])
+
+
+def test_load_npz_inputs_roundtrip(tmp_path):
+    """An archive's x array is read back unchanged, feature-first."""
+    rng = np.random.default_rng(0)
+    x = rng.random((3, 5))
+    path = tmp_path / "in.npz"
+    np.savez(path, x=x)
+    loaded = load_npz_inputs(path)
+    assert loaded.shape == (3, 5)
+    assert np.allclose(loaded, x)
+
+
+def test_load_npz_inputs_ignores_outputs_and_partials(tmp_path):
+    """Only x is returned; any y/dydx in the archive are ignored."""
+    x = np.arange(6.0).reshape((2, 3))
+    path = tmp_path / "full.npz"
+    np.savez(path, x=x, y=np.zeros((1, 3)), dydx=np.zeros((1, 2, 3)))
+    assert np.allclose(load_npz_inputs(path), x)
+
+
+def test_load_npz_inputs_missing_x(tmp_path):
+    """An archive without an x array raises ValueError."""
+    path = tmp_path / "no_x.npz"
+    np.savez(path, y=np.zeros((1, 3)))
+    with pytest.raises(ValueError, match="no array named"):
+        load_npz_inputs(path)
+
+
+def test_load_npz_inputs_rejects_non_2d(tmp_path):
+    """A 1-D x array is not feature-first -> ValueError."""
+    path = tmp_path / "flat.npz"
+    np.savez(path, x=np.zeros(5))
+    with pytest.raises(ValueError, match="2-D"):
+        load_npz_inputs(path)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -250,3 +250,163 @@ def test_scan_files_reads_fixture_columns():
     result = server._scan_files(DATA)  # ruff:ignore[private-member-access]
     fixture = next(f for f in result["files"] if f["name"] == "rastrigin.csv")
     assert fixture["columns"] == ["x1", "x2", "y", "slope_wrt_x1"]
+
+
+def _export_and_load(tmp_path, **train_kwargs):
+    """Train -> export -> load_model; return (loaded_dict, original_model, x)."""
+    rows, x = _rastrigin_rows()
+    trained = server.train(**rows, **train_kwargs)
+    path = tmp_path / "surrogate.json"
+    server.export(trained["model_id"], path=str(path))
+    loaded = server.load_model(str(path))
+    original = server._MODELS.get(trained["model_id"]).model  # ruff:ignore[private-member-access]
+    return loaded, original, x
+
+
+def test_load_model_and_predict_roundtrip(tmp_path):
+    """A reloaded model predicts identically to the original in-registry one."""
+    loaded, original, x = _export_and_load(
+        tmp_path,
+        hidden_layers=[12, 12],
+        max_iter=200,
+        random_state=0,
+    )
+    assert loaded["n_inputs"] == 2
+    assert loaded["n_outputs"] == 1
+    assert loaded["source"].endswith("surrogate.json")
+
+    # Inline row-per-sample x -> row-per-sample y that matches the original model.
+    pred = server.predict(loaded["model_id"], x=x.T.tolist())
+    assert np.allclose(np.array(pred["y"]), original.predict(x).T)
+
+
+def test_predict_inline_with_partials():
+    """Inline predict returns row-per-sample y, and dydx when requested."""
+    rows, _ = _rastrigin_rows()
+    mid = server.train(**rows, hidden_layers=[12], max_iter=100, random_state=0)[
+        "model_id"
+    ]
+    m = len(rows["x"])
+
+    res = server.predict(mid, x=rows["x"])
+    assert np.array(res["y"]).shape == (m, 1)  # (m, n_y)
+    assert "dydx" not in res
+
+    res = server.predict(mid, x=rows["x"], with_partials=True)
+    assert np.array(res["y"]).shape == (m, 1)
+    assert np.array(res["dydx"]).shape == (m, 1, 2)  # (m, n_y, n_x)
+
+
+def test_predict_from_csv_and_npz_paths(tmp_path):
+    """A CSV and an NPZ inputs file give the same result as inline arrays."""
+    rows, x = _rastrigin_rows()
+    mid = server.train(**rows, hidden_layers=[12], max_iter=100, random_state=0)[
+        "model_id"
+    ]
+
+    # CSV path: compare against inline on the identical fixture inputs.
+    x_csv = jenn.utilities.load_csv_inputs(DATA / "rastrigin.csv", inputs=["x1", "x2"])
+    from_csv = server.predict(
+        mid, path=str(DATA / "rastrigin.csv"), inputs=["x1", "x2"]
+    )
+    inline_csv = server.predict(mid, x=x_csv.T.tolist())
+    assert np.allclose(np.array(from_csv["y"]), np.array(inline_csv["y"]))
+
+    # NPZ path: feature-first x on disk -> same as inline row-per-sample.
+    npz = tmp_path / "inputs.npz"
+    np.savez(npz, x=x)  # feature-first (n_x, m)
+    from_npz = server.predict(mid, path=str(npz))
+    inline_x = server.predict(mid, x=x.T.tolist())
+    assert np.allclose(np.array(from_npz["y"]), np.array(inline_x["y"]))
+
+
+def test_predict_output_path_writes_file(tmp_path):
+    """output_path writes a file (feature-first NPZ / table CSV) and omits inline arrays."""
+    rows, _ = _rastrigin_rows()
+    mid = server.train(**rows, hidden_layers=[12], max_iter=50, random_state=0)[
+        "model_id"
+    ]
+    m = len(rows["x"])
+
+    # CSV: response-only table; inline arrays omitted.
+    csv_out = tmp_path / "pred.csv"
+    res = server.predict(mid, x=rows["x"], output_path=str(csv_out))
+    assert csv_out.exists()
+    assert "y" not in res
+    assert "dydx" not in res
+    assert res["n_samples"] == m
+
+    # NPZ with partials: feature-first x/y/dydx on disk.
+    npz_out = tmp_path / "pred.npz"
+    res = server.predict(mid, x=rows["x"], with_partials=True, output_path=str(npz_out))
+    assert "y" not in res
+    with np.load(npz_out) as arch:
+        assert set(arch.files) == {"x", "y", "dydx"}
+        assert arch["x"].shape == (2, m)  # feature-first
+        assert arch["dydx"].shape == (1, 2, m)
+
+    # CSV cannot hold 3-D partials -> steer to NPZ.
+    with pytest.raises(ValueError, match=r"use \.npz to write partials"):
+        server.predict(
+            mid,
+            x=rows["x"],
+            with_partials=True,
+            output_path=str(tmp_path / "bad.csv"),
+        )
+
+
+def test_predict_width_mismatch():
+    """Inputs whose width != model n_inputs raise a clear error."""
+    rows, _ = _rastrigin_rows()
+    mid = server.train(**rows, hidden_layers=[12], max_iter=20, random_state=0)[
+        "model_id"
+    ]
+    with pytest.raises(ValueError, match="does not match model n_inputs"):
+        server.predict(mid, x=[[0.1]])  # 1 feature, model expects 2
+
+
+def test_load_model_error_paths(tmp_path):
+    """Missing files and non-JENN JSON raise clear errors."""
+    with pytest.raises(ValueError, match="No such file"):
+        server.load_model(str(tmp_path / "nope.json"))
+
+    bad = tmp_path / "bad.json"
+    bad.write_text('{"hello": 1}')  # valid JSON, not a JENN model
+    with pytest.raises(ValueError, match="not a valid JENN model file"):
+        server.load_model(str(bad))
+
+
+def test_evaluate_on_loaded_model(tmp_path):
+    """A data-less loaded model errors on the training-data path, scores on holdout."""
+    loaded, _, _ = _export_and_load(
+        tmp_path,
+        hidden_layers=[12],
+        max_iter=100,
+        random_state=0,
+    )
+    mid = loaded["model_id"]
+
+    # No x/y: nothing to score against -> the new guard.
+    with pytest.raises(ValueError, match="no training data"):
+        server.evaluate(mid)
+
+    # Holdout data -> scores normally (dimension check now uses layer_sizes).
+    holdout, _ = _rastrigin_rows(m_levels=11)
+    ev = server.evaluate(mid, **holdout)
+    assert ev["dataset"] == "holdout"
+    assert ev["metrics"]["response"]["r2_per_output"][0] > 0.5
+
+
+def test_list_models_surfaces_loaded_model(tmp_path):
+    """list_models tolerates data-less records (n_samples None) and shows source."""
+    loaded, _, _ = _export_and_load(
+        tmp_path,
+        hidden_layers=[12],
+        max_iter=20,
+        random_state=0,
+    )
+    entry = next(
+        m for m in server.list_models()["models"] if m["model_id"] == loaded["model_id"]
+    )
+    assert entry["n_samples"] is None
+    assert entry["source"] == loaded["source"]


### PR DESCRIPTION
Closes #45.

## What was the problem?

The JENN MCP server could **train** a model and **save** it to a file, but it
had no way to **reopen** that saved file in a later session and use it. So if you
trained a good model last week, this week you were stuck — there was no "load the
saved model" command, and no plain "run the model on new inputs" command either.
(The existing `evaluate` command only *grades* a model against answers you
already know; it can't just produce predictions.)

## What does this add?

Two new commands:

- **`load_model`** — open a model file you saved earlier and make it usable again.
- **`predict`** — give a model new inputs and get its outputs back (and, if you
  ask, the slopes/derivatives too).

Nice-to-haves that come with `predict`:

- New inputs can be typed in directly, **or** read from a spreadsheet-style
  `.csv` file or a NumPy `.npz` file — so you don't have to paste big tables.
- Results come back to you directly, **or** can be written to a file (for very
  large runs) instead.

A few small supporting changes let a freshly-loaded model — which carries only
the trained weights, not the original training data — work smoothly with the
existing commands, and give a clear, friendly error if you ask it to do something
it can't (like grade itself when it has no data to grade against).

## What's the result?

The whole "train once, reuse later" loop now works end to end: in a brand-new
session you can find a saved model, load it, and run it on fresh data — no
retraining, no copy-pasting arrays. All the existing commands behave exactly as
before.

## How to check

- **Automated tests** (all passing): `pixi run -e dev test-unit`. The new tests
  train a model, save it, load it back in, and confirm the reloaded model's
  predictions are *identical* to the original — plus checks for reading inputs
  from `.csv`/`.npz`, writing results to a file, and the helpful error messages.
- **By hand:** train and export a model, then in a new session call `load_model`
  on the saved file and `predict` on some inputs.

## Notes for the reviewer

- This builds on the file-loading work from #44, which is already merged into
  `master`, so this PR targets `master` and the diff is only the new reuse
  feature (one commit).
- One intentional convention: a `.csv` file is laid out one row per data point
  (like a spreadsheet), while a `.npz` file uses JENN's internal array layout.
  This is spelled out in the README and in `predict`'s help text so users aren't
  surprised.
